### PR TITLE
fix(enum): add interface

### DIFF
--- a/src/main/java/com/caizi/HomewardLib.java
+++ b/src/main/java/com/caizi/HomewardLib.java
@@ -27,8 +27,6 @@ public final class HomewardLib extends JavaPlugin {
         registerCommands();
         loadConfigurations();
         // Plugin startup logic
-
-
     }
 
     private void registerCommands() {

--- a/src/main/java/com/caizi/compatibilities/CompatibilityManager.java
+++ b/src/main/java/com/caizi/compatibilities/CompatibilityManager.java
@@ -1,29 +1,36 @@
 package com.caizi.compatibilities;
 
+import com.caizi.compatibilities.enumerate.BaseCompatiblePlugin;
 import com.caizi.utils.logs.ConsoleLogger;
 import com.caizi.utils.logs.LoggerManipulationType;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 
-import java.util.Arrays;
 import java.util.HashMap;
 
+// TODO 写文档注释
+
+/**
+ * ???
+ *
+ * @since ?
+ * @author ?
+ */
 public class CompatibilityManager {
 
     public final HashMap<Plugin, Class<? extends Listener>> ACTIVATED_COMPATIBILITY = new HashMap<>();
-    private Plugin plugin;
-    private ConsoleLogger logger;
-    private CompatibilityListener compatibilityListener;
+    private final Plugin plugin;
+    private final ConsoleLogger logger;
+    private final CompatibilityListener compatibilityListener;
     protected final HashMap<String, Class<? extends Listener>> UNLOADED_COMPATIBILITY = new HashMap<>();
     private final String COMPATIBILITY_PACKAGE_NAME = "compatibilities.provided";
 
-
-    public CompatibilityManager(Plugin plugin, ConsoleLogger logger, Class<? extends Listener> clazz) {
+    public CompatibilityManager(Plugin plugin, ConsoleLogger logger, Class<? extends Listener> clazz, BaseCompatiblePlugin... compatiblePlugins) {
         this.plugin = plugin;
         this.logger = logger;
         compatibilityListener = new CompatibilityListener(logger, plugin);
-        addUnloadedCompatibilityList();
+        addUnloadedCompatibilityList(compatiblePlugins);
         addActivatedCompatibilityList(clazz);
         registerCompatibility();
     }
@@ -37,13 +44,12 @@ public class CompatibilityManager {
         ACTIVATED_COMPATIBILITY.put(plugin, clazz);
     }
 
-    protected void addUnloadedCompatibilityList() {
-
-        Arrays.stream(CompatibilityList.values()).toList().forEach(K -> {
-            if (Bukkit.getPluginManager().isPluginEnabled(K.getPluginName()) && K.getNative()) {
-                UNLOADED_COMPATIBILITY.put(K.getPluginName(), K.getCompatibilityPlugin());
+    private void addUnloadedCompatibilityList(BaseCompatiblePlugin... compatiblePlugins) {
+        for (BaseCompatiblePlugin compatiblePlugin : compatiblePlugins) {
+            if (Bukkit.getPluginManager().isPluginEnabled(compatiblePlugin.getPluginName()) && compatiblePlugin.getNative()) {
+                UNLOADED_COMPATIBILITY.put(compatiblePlugin.getPluginName(), compatiblePlugin.getCompatibilityPlugin());
             }
-        });
+        }
     }
 
     private void registerCompatibility() {
@@ -61,6 +67,4 @@ public class CompatibilityManager {
 
         });
     }
-
-
 }

--- a/src/main/java/com/caizi/compatibilities/enumerate/BaseCompatiblePlugin.java
+++ b/src/main/java/com/caizi/compatibilities/enumerate/BaseCompatiblePlugin.java
@@ -1,0 +1,12 @@
+package com.caizi.compatibilities.enumerate;
+
+import org.bukkit.event.Listener;
+
+// 其他项目的枚举继承这个
+public interface BaseCompatiblePlugin {
+    String getPluginName();
+
+    boolean getNative();
+
+    Class<? extends Listener> getCompatibilityPlugin();
+}

--- a/src/main/java/com/caizi/compatibilities/enumerate/CompatiblePlugin.java
+++ b/src/main/java/com/caizi/compatibilities/enumerate/CompatiblePlugin.java
@@ -1,15 +1,15 @@
-package com.caizi.compatibilities;
+package com.caizi.compatibilities.enumerate;
 
 import com.caizi.compatibilities.provided.minecraft.MinecraftCompatibility;
 import org.bukkit.event.Listener;
 
-public enum CompatibilityList {
+public enum CompatiblePlugin implements BaseCompatiblePlugin {
 
 //    MMOITEMS("MMOItems", true, MMOItemsCompatibility.class),
 //    ITEMSADDER("ItemsAdder", true, ItemsAdderCompatibility.class),
     MINECRAFT("Minecraft", true, MinecraftCompatibility.class);
 
-    private final Boolean isNative;
+    private final boolean isNative;
     private String pluginName;
     private Class<? extends Listener> compatibilityPlugin;
 
@@ -21,17 +21,18 @@ public enum CompatibilityList {
      * @param isNative
      * @param compatibilityPlugin
      */
-    CompatibilityList(String pluginName, Boolean isNative, Class<? extends Listener> compatibilityPlugin) {
+    CompatiblePlugin(String pluginName, boolean isNative, Class<? extends Listener> compatibilityPlugin) {
         this.pluginName = pluginName;
         this.isNative = isNative;
         this.compatibilityPlugin = compatibilityPlugin;
     }
 
-    CompatibilityList(String pluginName, Boolean isNative) {
+    CompatiblePlugin(String pluginName, boolean isNative) {
         this.pluginName = pluginName;
         this.isNative = isNative;
     }
 
+    @Override
     public String getPluginName() {
         return pluginName;
     }
@@ -41,10 +42,12 @@ public enum CompatibilityList {
 
     }
 
-    public Boolean getNative() {
+    @Override
+    public boolean getNative() {
         return isNative;
     }
 
+    @Override
     public Class<? extends Listener> getCompatibilityPlugin() {
         return compatibilityPlugin;
     }


### PR DESCRIPTION
become more flexible:
- add BaseCompatiblePlugin.java interface thus you can implement it.

BREAK CHANGE: the enumeration name "CompatibilityList" change to "CompatiblePlugin" and move it to new package "com.caizi.compatibilities.enumerate.CompatiblePlugin"